### PR TITLE
feat: define domain contracts for new runtime

### DIFF
--- a/docs-v2/components/agents-and-nodes.md
+++ b/docs-v2/components/agents-and-nodes.md
@@ -23,6 +23,10 @@ Nodes can optionally pull reflections or prior decisions from memory adapters vi
 - Unit tests mock `SessionDataContext` and `ExternalApiGateway` to ensure nodes consume/publish the correct artifacts.
 - E2E tests verify end-to-end decision parity under mocked conditions.
 
+## Implementation Notes
+- Analysis nodes live in `tradingagents/application/nodes/analysis.py` and emit `analysis.*` artifacts.
+- Debate and decision nodes are defined in `tradingagents/application/nodes/debate.py` and operate on the shared context outputs.
+
 ## Related Documents
 - [Final Architecture](../new-architecture/final-architecture.md)
 - [Legacy vs Modern Comparison](../legacy-vs-modern.md)

--- a/docs-v2/components/data-platform.md
+++ b/docs-v2/components/data-platform.md
@@ -20,6 +20,8 @@ flowchart LR
 - Keep adapters stateless; configuration (API keys, endpoints) injected via environment/config objects.
 - Mock the gateway in tests to ensure deterministic outcomes.
 - Support offline modes by routing to cached datasets.
+- Implementation scaffolding lives in `tradingagents/infrastructure/external/`.
+- Raw data bootstrapping is implemented in `tradingagents/application/bootstrap/bootstrapper.py` using nodes from `tradingagents/application/nodes/data_fetch.py`.
 
 ## Related Documents
 - [Master Plan](../implementation/master-plan.md)

--- a/docs-v2/components/session-orchestration.md
+++ b/docs-v2/components/session-orchestration.md
@@ -29,6 +29,7 @@ sequenceDiagram
 - Add new nodes by defining their `NodeSpec` and registering with the planner.
 - Use feature flags to swap execution engines if required (e.g., legacy LangGraph vs new runtime).
 - Capture execution metrics in the executor to support observability initiatives.
+- Runtime scaffolding lives in `tradingagents/application/` (`planner.py`, `executor.py`, `session.py`).
 
 ## Related Documents
 - [Master Plan](../implementation/master-plan.md)

--- a/docs-v2/implementation/master-plan.md
+++ b/docs-v2/implementation/master-plan.md
@@ -7,11 +7,11 @@ This master plan governs the rollout of the SOLID-aligned architecture described
 | Story | Title | Status | Owner | Validation Summary |
 |-------|-------|--------|-------|--------------------|
 | S1 | Establish Mocked E2E Safety Net | ✅ Done | Core team | `pytest -m e2e` (mocked) |
-| S2 | Define Domain Contracts | ⏳ Pending | Architecture squad | `pytest tests/domain -q`, `pytest -m e2e` |
-| S3 | Introduce External API Gateway | ⏳ Pending | Infrastructure squad | `pytest tests/domain tests/infrastructure -q`, `pytest -m e2e` |
-| S4 | Bootstrap Raw Data via Fetch Nodes | ⏳ Pending | Data platform squad | `pytest tests/domain tests/infrastructure tests/application -q`, `pytest -m e2e` |
-| S5 | Migrate Analysts & Debaters to Graph Nodes | ⏳ Pending | Research agents squad | `pytest tests/application -q`, `pytest -m e2e` |
-| S6 | Implement Planner, Executor, and Session Facade | ⏳ Pending | Runtime squad | `pytest tests/application tests/domain -q`, `pytest -m e2e` |
+| S2 | Define Domain Contracts | ✅ Done | Architecture squad | `pytest tests/domain -q`, `pytest -m e2e` |
+| S3 | Introduce External API Gateway | ✅ Done | Infrastructure squad | `pytest tests/domain tests/infrastructure -q`, `pytest -m e2e` |
+| S4 | Bootstrap Raw Data via Fetch Nodes | ✅ Done | Data platform squad | `pytest tests/domain tests/infrastructure tests/application -q`, `pytest -m e2e` |
+| S5 | Migrate Analysts & Debaters to Graph Nodes | ✅ Done | Research agents squad | `pytest tests/application -q`, `pytest -m e2e` |
+| S6 | Implement Planner, Executor, and Session Facade | ✅ Done | Runtime squad | `pytest tests/application tests/domain -q`, `pytest -m e2e` |
 | S7 | Retire Legacy Toolkit & Interfaces | ⏳ Pending | Core maintainers | `pytest`, `pytest -m e2e` |
 | S8 | Enhance Observability & Documentation | ⏳ Pending | Ops & Docs squad | `pytest`, `pytest -m e2e`, manual doc review |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "tushare>=1.4.21",
     "typing-extensions>=4.14.0",
     "yfinance>=0.2.63",
+    "typer>=0.12.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ rich
 questionary
 langchain_anthropic
 langchain-google-genai
+typer

--- a/tests/application/test_analysis_nodes.py
+++ b/tests/application/test_analysis_nodes.py
@@ -1,0 +1,84 @@
+from collections import deque
+
+import pytest
+
+from tradingagents.application.nodes import (
+    FundamentalsAnalysisNode,
+    MarketAnalysisNode,
+    NewsAnalysisNode,
+    SentimentAnalysisNode,
+)
+from tradingagents.domain import SessionDataContext
+
+
+class StubGateway:
+    def __init__(self, responses):
+        self._responses = {
+            key: deque([value] if not isinstance(value, (list, tuple)) else value)
+            for key, value in responses.items()
+        }
+        self.calls = []
+
+    def invoke(self, provider, operation, payload):
+        key = (provider, operation)
+        self.calls.append((provider, operation, payload))
+        queue = self._responses.get(key)
+        if not queue:
+            raise AssertionError(f"No response queued for {key}")
+        outcome = queue.popleft()
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+
+@pytest.fixture
+def context_with_raw():
+    context = SessionDataContext(
+        {
+            "session.ticker": "AAPL",
+            "session.as_of": "2024-07-04",
+            "raw.market": {"prices": [1, 2]},
+            "raw.news": ["headline"],
+            "raw.fundamentals": {"pe": 10},
+            "raw.sentiment": {"score": 0.4},
+        }
+    )
+    return context
+
+
+def test_market_analysis_node_returns_report(context_with_raw):
+    gateway = StubGateway({("openai", "analyze_market"): [{"report": "market"}]})
+    node = MarketAnalysisNode()
+
+    result = node.execute(context_with_raw, gateway)
+
+    assert result == {"analysis.market_report": "market"}
+    assert gateway.calls[0][2]["market_data"] == {"prices": [1, 2]}
+
+
+def test_news_analysis_node_uses_news_items(context_with_raw):
+    gateway = StubGateway({("openai", "analyze_news"): [{"report": "news"}]})
+    node = NewsAnalysisNode()
+
+    result = node.execute(context_with_raw, gateway)
+
+    assert result["analysis.news_report"] == "news"
+    assert gateway.calls[0][2]["news_items"] == ["headline"]
+
+
+def test_fundamentals_analysis_node(context_with_raw):
+    gateway = StubGateway({("openai", "analyze_fundamentals"): [{"report": "fund"}]})
+    node = FundamentalsAnalysisNode()
+
+    result = node.execute(context_with_raw, gateway)
+
+    assert result == {"analysis.fundamentals_report": "fund"}
+
+
+def test_sentiment_analysis_node(context_with_raw):
+    gateway = StubGateway({("openai", "analyze_sentiment"): [{"report": "sent"}]})
+    node = SentimentAnalysisNode()
+
+    result = node.execute(context_with_raw, gateway)
+
+    assert result == {"analysis.sentiment_report": "sent"}

--- a/tests/application/test_data_bootstrapper.py
+++ b/tests/application/test_data_bootstrapper.py
@@ -1,0 +1,120 @@
+from collections import deque
+
+import pytest
+
+from tradingagents.application import DataBootstrapper, BootstrapFailure
+from tradingagents.application.nodes import default_data_fetch_nodes
+from tradingagents.domain import SessionDataContext
+
+
+class StubGateway:
+    def __init__(self, responses):
+        self._responses = {
+            key: deque(value if isinstance(value, (list, tuple)) else [value])
+            for key, value in responses.items()
+        }
+        self.calls = []
+
+    def invoke(self, provider, operation, payload):
+        key = (provider, operation)
+        self.calls.append((provider, operation, payload))
+        queue = self._responses.get(key)
+        if not queue:
+            raise AssertionError(f"No response queued for {key}")
+        outcome = queue.popleft()
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+
+def test_bootstrap_publishes_raw_artifacts():
+    context = SessionDataContext()
+    gateway = StubGateway(
+        {
+            ("yahoo_finance", "historical_prices"): [{"prices": [1, 2]}],
+            ("finnhub", "company_news"): [{"articles": ["headline"]}],
+            ("simfin", "fundamentals_snapshot"): [{"balance_sheet": {}}],
+            ("reddit", "social_sentiment"): [{"sentiment": 0.5}],
+        }
+    )
+    bootstrapper = DataBootstrapper(default_data_fetch_nodes())
+
+    published = bootstrapper.bootstrap(
+        context,
+        gateway,
+        ticker="AAPL",
+        as_of="2024-07-04",
+    )
+
+    assert context.require("raw.market") == {"prices": [1, 2]}
+    assert context.require("raw.news")["articles"] == ["headline"]
+    assert context.require("raw.fundamentals") == {"balance_sheet": {}}
+    assert context.require("raw.sentiment") == {"sentiment": 0.5}
+    assert set(published) == {
+        "raw.market",
+        "raw.news",
+        "raw.fundamentals",
+        "raw.sentiment",
+    }
+
+
+def test_bootstrap_raises_on_gateway_error():
+    context = SessionDataContext()
+    gateway = StubGateway(
+        {
+            ("yahoo_finance", "historical_prices"): [RuntimeError("boom")],
+        }
+    )
+    bootstrapper = DataBootstrapper(default_data_fetch_nodes())
+
+    with pytest.raises(BootstrapFailure) as excinfo:
+        bootstrapper.bootstrap(
+            context,
+            gateway,
+            ticker="AAPL",
+            as_of="2024-07-04",
+        )
+
+    assert excinfo.value.node_id == "data.fetch.market"
+
+
+def test_bootstrap_detects_metadata_conflicts():
+    context = SessionDataContext({"session.ticker": "MSFT", "session.as_of": "2024-07-01"})
+    gateway = StubGateway({})
+    bootstrapper = DataBootstrapper(default_data_fetch_nodes())
+
+    with pytest.raises(BootstrapFailure):
+        bootstrapper.bootstrap(
+            context,
+            gateway,
+            ticker="AAPL",
+            as_of="2024-07-04",
+        )
+
+
+def test_bootstrap_skips_existing_artifacts():
+    context = SessionDataContext({
+        "session.ticker": "AAPL",
+        "session.as_of": "2024-07-04",
+        "raw.market": {"prices": [0]},
+    })
+    gateway = StubGateway(
+        {
+            ("yahoo_finance", "historical_prices"): [{"prices": [1, 2]}],
+            ("finnhub", "company_news"): [{"articles": []}],
+            ("simfin", "fundamentals_snapshot"): [{"balance_sheet": {}}],
+            ("reddit", "social_sentiment"): [{"sentiment": 0.1}],
+        }
+    )
+    bootstrapper = DataBootstrapper(default_data_fetch_nodes())
+
+    published = bootstrapper.bootstrap(
+        context,
+        gateway,
+        ticker="AAPL",
+        as_of="2024-07-04",
+    )
+
+    assert context.require("raw.market") == {"prices": [0]}
+    assert "raw.market" not in published
+    assert context.require("raw.news") == {"articles": []}

--- a/tests/application/test_data_fetch_nodes.py
+++ b/tests/application/test_data_fetch_nodes.py
@@ -1,0 +1,87 @@
+from collections import deque
+
+from tradingagents.application.nodes import (
+    FundamentalsDataFetchNode,
+    MarketDataFetchNode,
+    NewsDataFetchNode,
+    SentimentDataFetchNode,
+)
+from tradingagents.domain import SessionDataContext
+
+
+class StubGateway:
+    def __init__(self):
+        self.calls = []
+        self.responses = deque()
+
+    def enqueue(self, response):
+        self.responses.append(response)
+
+    def invoke(self, provider, operation, payload):
+        self.calls.append((provider, operation, payload))
+        if not self.responses:
+            raise AssertionError("No queued response for gateway call")
+        outcome = self.responses.popleft()
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+
+def _context_with_metadata():
+    context = SessionDataContext()
+    context.publish("session.ticker", "AAPL")
+    context.publish("session.as_of", "2024-07-04")
+    return context
+
+
+def test_market_fetch_node_invokes_gateway_with_window():
+    gateway = StubGateway()
+    gateway.enqueue({"prices": []})
+    node = MarketDataFetchNode(lookback_days=10)
+    context = _context_with_metadata()
+
+    result = node.execute(context, gateway)
+
+    assert result == {"raw.market": {"prices": []}}
+    provider, operation, payload = gateway.calls[0]
+    assert provider == "yahoo_finance"
+    assert operation == "historical_prices"
+    assert payload["window_days"] == 10
+
+
+def test_news_fetch_node_includes_limit_and_window():
+    gateway = StubGateway()
+    gateway.enqueue({"articles": []})
+    node = NewsDataFetchNode(window_days=5, limit=12)
+    context = _context_with_metadata()
+
+    node.execute(context, gateway)
+
+    payload = gateway.calls[0][2]
+    assert payload["window_days"] == 5
+    assert payload["limit"] == 12
+
+
+def test_fundamentals_fetch_node_produces_expected_key():
+    gateway = StubGateway()
+    gateway.enqueue({"balance_sheet": {}})
+    node = FundamentalsDataFetchNode()
+    context = _context_with_metadata()
+
+    result = node.execute(context, gateway)
+
+    assert "raw.fundamentals" in result
+
+
+def test_sentiment_fetch_node_uses_reddit_provider():
+    gateway = StubGateway()
+    gateway.enqueue({"posts": []})
+    node = SentimentDataFetchNode(window_days=2)
+    context = _context_with_metadata()
+
+    node.execute(context, gateway)
+
+    provider, operation, payload = gateway.calls[0]
+    assert provider == "reddit"
+    assert operation == "social_sentiment"
+    assert payload["window_days"] == 2

--- a/tests/application/test_debate_nodes.py
+++ b/tests/application/test_debate_nodes.py
@@ -1,0 +1,93 @@
+from collections import deque
+
+import pytest
+
+from tradingagents.application.nodes import (
+    BearResearchNode,
+    BullResearchNode,
+    RiskAssessmentNode,
+    TraderDecisionNode,
+)
+from tradingagents.domain import SessionDataContext
+
+
+class StubGateway:
+    def __init__(self, responses):
+        self._responses = {
+            key: deque([value] if not isinstance(value, (list, tuple)) else value)
+            for key, value in responses.items()
+        }
+        self.calls = []
+
+    def invoke(self, provider, operation, payload):
+        key = (provider, operation)
+        self.calls.append((provider, operation, payload))
+        queue = self._responses.get(key)
+        if not queue:
+            raise AssertionError(f"No response queued for {key}")
+        outcome = queue.popleft()
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+
+@pytest.fixture
+def context_with_analysis():
+    context = SessionDataContext(
+        {
+            "session.ticker": "AAPL",
+            "session.as_of": "2024-07-04",
+            "analysis.market_report": "market",
+            "analysis.news_report": "news",
+            "analysis.fundamentals_report": "fund",
+            "analysis.sentiment_report": "sentiment",
+            "debate.bull_case": "bull",
+            "debate.bear_case": "bear",
+            "decision.trader_plan": "plan",
+        }
+    )
+    return context
+
+
+def test_bull_research_node_builds_case(context_with_analysis):
+    gateway = StubGateway({("openai", "compose_bull_case"): [{"content": "bull-case"}]})
+    node = BullResearchNode()
+
+    result = node.execute(context_with_analysis, gateway)
+
+    assert result == {"debate.bull_case": "bull-case"}
+    payload = gateway.calls[0][2]
+    assert payload["market_report"] == "market"
+    assert payload["sentiment_report"] == "sentiment"
+
+
+def test_bear_research_node_builds_case(context_with_analysis):
+    gateway = StubGateway({("openai", "compose_bear_case"): [{"content": "bear-case"}]})
+    node = BearResearchNode()
+
+    result = node.execute(context_with_analysis, gateway)
+
+    assert result == {"debate.bear_case": "bear-case"}
+
+
+def test_trader_decision_node_returns_plan(context_with_analysis):
+    gateway = StubGateway({("openai", "draft_trader_plan"): [{"plan": "plan-out"}]})
+    node = TraderDecisionNode()
+
+    result = node.execute(context_with_analysis, gateway)
+
+    assert result == {"decision.trader_plan": "plan-out"}
+    payload = gateway.calls[0][2]
+    assert payload["bull_case"] == "bull"
+    assert payload["bear_case"] == "bear"
+
+
+def test_risk_assessment_node(context_with_analysis):
+    gateway = StubGateway({("openai", "assess_risk"): [{"assessment": "risk"}]})
+    node = RiskAssessmentNode()
+
+    result = node.execute(context_with_analysis, gateway)
+
+    assert result == {"risk.assessment": "risk"}
+    payload = gateway.calls[0][2]
+    assert payload["trader_plan"] == "plan"

--- a/tests/application/test_runtime.py
+++ b/tests/application/test_runtime.py
@@ -1,0 +1,151 @@
+from collections import deque
+
+import pytest
+
+from tradingagents.application import (
+    DataBootstrapper,
+    DependencyPlanner,
+    NodeExecutor,
+    TradingSession,
+)
+from tradingagents.application.nodes import default_node_specs
+from tradingagents.domain import NodeSpec, NodeKind, SessionDataContext
+
+
+class GatewayStub:
+    def __init__(self, responses):
+        self._responses = {
+            key: deque([value] if not isinstance(value, (list, tuple)) else value)
+            for key, value in responses.items()
+        }
+        self.calls = []
+
+    def invoke(self, provider, operation, payload):
+        key = (provider, operation)
+        self.calls.append((provider, operation, payload))
+        queue = self._responses.get(key)
+        if not queue:
+            raise AssertionError(f"No response queued for {key}")
+        outcome = queue.popleft()
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+
+class IncrementingNode:
+    def __init__(self, node_id: str, produces: str, *, fail_once: bool = False):
+        self.id = node_id
+        self.node_kind = NodeKind.ANALYSIS
+        self.requires = frozenset()
+        self.produces = frozenset({produces})
+        self._produces = produces
+        self._fail_once = fail_once
+        self._called = False
+
+    def execute(self, context: SessionDataContext, gateway: object):
+        if self._fail_once and not self._called:
+            self._called = True
+            raise RuntimeError("transient")
+        return {self._produces: context.snapshot().get(self._produces, 0) + 1}
+
+
+def _analysis_gateway_responses():
+    return {
+        ("yahoo_finance", "historical_prices"): [{"report": "prices"}],
+        ("finnhub", "company_news"): [{"report": "news"}],
+        ("simfin", "fundamentals_snapshot"): [{"report": "fund"}],
+        ("reddit", "social_sentiment"): [{"report": "sent"}],
+        ("openai", "analyze_market"): [{"report": "market"}],
+        ("openai", "analyze_news"): [{"report": "news-report"}],
+        ("openai", "analyze_fundamentals"): [{"report": "fund-report"}],
+        ("openai", "analyze_sentiment"): [{"report": "sent-report"}],
+        ("openai", "compose_bull_case"): [{"content": "bull"}],
+        ("openai", "compose_bear_case"): [{"content": "bear"}],
+        ("openai", "draft_trader_plan"): [{"plan": "plan"}],
+        ("openai", "assess_risk"): [{"assessment": "risk"}],
+    }
+
+
+def test_dependency_planner_orders_nodes():
+    specs = default_node_specs()
+    planner = DependencyPlanner(specs)
+    context = SessionDataContext(
+        {
+            "session.ticker": "AAPL",
+            "session.as_of": "2024-07-04",
+            "raw.market": {},
+            "raw.news": {},
+            "raw.fundamentals": {},
+            "raw.sentiment": {},
+        }
+    )
+
+    plan = planner.plan(context)
+
+    assert [spec.id for spec in plan] == [
+        "analysis.fundamentals",
+        "analysis.market",
+        "analysis.news",
+        "analysis.sentiment",
+        "debate.bear",
+        "debate.bull",
+        "decision.trader",
+        "risk.assessment",
+    ]
+
+
+def test_node_executor_runs_plan():
+    context = SessionDataContext(
+        {
+            "session.ticker": "AAPL",
+            "session.as_of": "2024-07-04",
+            "raw.market": {},
+            "raw.news": {},
+            "raw.fundamentals": {},
+            "raw.sentiment": {},
+        }
+    )
+    gateway = GatewayStub(_analysis_gateway_responses())
+    planner = DependencyPlanner(default_node_specs())
+    plan = planner.plan(context)
+
+    executor = NodeExecutor()
+    records = executor.execute(plan, context, gateway)
+
+    assert context.require("risk.assessment") == "risk"
+    assert [record.node_id for record in records][-1] == "risk.assessment"
+
+
+def test_node_executor_retries_failures():
+    spec = NodeSpec(
+        id="test.node",
+        node_kind=NodeKind.ANALYSIS,
+        requires=frozenset(),
+        produces=frozenset({"analysis.value"}),
+        factory=lambda: IncrementingNode("test.node", "analysis.value", fail_once=True),
+    )
+    context = SessionDataContext()
+    executor = NodeExecutor(max_retries=1)
+    records = executor.execute([spec], context, gateway=object())
+
+    assert context.require("analysis.value") == 1
+    assert records[0].attempts == 2
+
+
+def test_trading_session_runs_pipeline():
+    gateway = GatewayStub(_analysis_gateway_responses())
+    bootstrapper = DataBootstrapper()
+    session = TradingSession(
+        bootstrapper=bootstrapper,
+        planner=DependencyPlanner(default_node_specs()),
+        executor=NodeExecutor(),
+        gateway=gateway,
+        node_specs=default_node_specs(),
+    )
+
+    result = session.run(ticker="AAPL", as_of="2024-07-04")
+
+    artifacts = result.context.snapshot()
+    assert artifacts["risk.assessment"] == "risk"
+    assert "analysis.market_report" in artifacts
+    assert result.plan[-1] == "risk.assessment"

--- a/tests/domain/test_node_spec.py
+++ b/tests/domain/test_node_spec.py
@@ -1,0 +1,106 @@
+from dataclasses import dataclass
+from typing import Mapping
+
+import pytest
+
+from tradingagents.domain import NodeKind
+from tradingagents.domain.nodes import NodeSpec
+from tradingagents.domain.context import SessionDataContext
+
+
+@dataclass
+class DummyNode:
+    id: str
+    node_kind: NodeKind
+    requires: frozenset[str]
+    produces: frozenset[str]
+
+    def execute(self, context: SessionDataContext, gateway: object) -> Mapping[str, object]:
+        return {key: f"value for {key}" for key in self.produces}
+
+
+class DummyFactory:
+    def __init__(self, node: DummyNode) -> None:
+        self.node = node
+        self.calls = 0
+
+    def __call__(self, **_: object) -> DummyNode:
+        self.calls += 1
+        return self.node
+
+
+def test_instantiate_returns_valid_node():
+    node = DummyNode(
+        id="analysis.market",
+        node_kind=NodeKind.ANALYSIS,
+        requires=frozenset({"raw.market"}),
+        produces=frozenset({"analysis.market_report"}),
+    )
+    factory = DummyFactory(node)
+    spec = NodeSpec(
+        id="analysis.market",
+        node_kind=NodeKind.ANALYSIS,
+        requires=node.requires,
+        produces=node.produces,
+        factory=factory,
+        description="Market analyst",
+    )
+
+    created = spec.instantiate()
+
+    assert created is node
+    assert factory.calls == 1
+
+
+def test_instantiate_validates_identity_and_metadata():
+    node = DummyNode(
+        id="wrong",
+        node_kind=NodeKind.ANALYSIS,
+        requires=frozenset({"raw.market"}),
+        produces=frozenset({"analysis.market_report"}),
+    )
+    spec = NodeSpec(
+        id="analysis.market",
+        node_kind=NodeKind.ANALYSIS,
+        requires=frozenset({"raw.market"}),
+        produces=frozenset({"analysis.market_report"}),
+        factory=lambda: node,
+    )
+
+    with pytest.raises(ValueError):
+        spec.instantiate()
+
+
+def test_missing_factory_raises_type_error():
+    spec = NodeSpec(
+        id="analysis.market",
+        node_kind=NodeKind.ANALYSIS,
+        requires=frozenset({"raw.market"}),
+        produces=frozenset({"analysis.market_report"}),
+    )
+
+    with pytest.raises(TypeError):
+        spec.instantiate()
+
+
+@pytest.mark.parametrize(
+    "requires,produces",
+    [
+        (frozenset({"raw.market"}), frozenset({"analysis.market_report"})),
+        (frozenset(), frozenset()),
+    ],
+)
+def test_to_dict_serialises_metadata(requires: frozenset[str], produces: frozenset[str]):
+    spec = NodeSpec(
+        id="analysis.market",
+        node_kind=NodeKind.ANALYSIS,
+        requires=requires,
+        produces=produces,
+    )
+
+    payload = spec.to_dict()
+
+    assert payload["id"] == "analysis.market"
+    assert payload["node_kind"] == NodeKind.ANALYSIS.value
+    assert payload["requires"] == sorted(requires)
+    assert payload["produces"] == sorted(produces)

--- a/tests/domain/test_session_data_context.py
+++ b/tests/domain/test_session_data_context.py
@@ -1,0 +1,53 @@
+from datetime import datetime
+
+import pytest
+
+from tradingagents.domain import (
+    DuplicateArtifactError,
+    InvalidArtifactNamespaceError,
+    MissingArtifactError,
+    SessionDataContext,
+)
+
+
+def test_require_returns_published_value():
+    context = SessionDataContext({"raw.market": {"price": 123}})
+    assert context.require("raw.market") == {"price": 123}
+
+
+def test_require_raises_for_missing_key():
+    context = SessionDataContext()
+    with pytest.raises(MissingArtifactError):
+        context.require("analysis.market_report")
+
+
+def test_publish_rejects_duplicate_keys():
+    context = SessionDataContext()
+    context.publish("raw.market", {"price": 100})
+    with pytest.raises(DuplicateArtifactError):
+        context.publish("raw.market", {"price": 101})
+
+
+@pytest.mark.parametrize("invalid_key", ["raw", "", "analysis."])
+def test_publish_rejects_invalid_namespaces(invalid_key: str):
+    context = SessionDataContext()
+    with pytest.raises(InvalidArtifactNamespaceError):
+        context.publish(invalid_key, {})
+
+
+def test_is_ready_checks_all_requirements():
+    context = SessionDataContext({"raw.market": {}})
+    assert not context.is_ready({"raw.market", "raw.news"})
+    context.publish("raw.news", {"headlines": []})
+    assert context.is_ready({"raw.market", "raw.news"})
+
+
+def test_snapshot_returns_copy():
+    context = SessionDataContext()
+    payload = {"timestamp": datetime(2024, 1, 1)}
+    context.publish("analysis.market_report", payload)
+
+    snapshot = context.snapshot()
+    assert snapshot == {"analysis.market_report": payload}
+    snapshot["analysis.market_report"] = {}
+    assert context.require("analysis.market_report") is payload

--- a/tests/e2e/test_graph_flow.py
+++ b/tests/e2e/test_graph_flow.py
@@ -19,8 +19,15 @@ def _base_config(tmp_path, **overrides):
 
 
 @pytest.mark.e2e
-def test_trading_graph_propagate_returns_buy_signal(mock_runtime, tmp_path):
-    config = _base_config(tmp_path, online_tools=False)
+@pytest.mark.parametrize("use_new_runtime", [False, True])
+def test_trading_graph_propagate_returns_buy_signal(
+    mock_runtime, tmp_path, use_new_runtime
+):
+    config = _base_config(
+        tmp_path,
+        online_tools=False,
+        use_new_runtime=use_new_runtime,
+    )
 
     graph = TradingAgentsGraph(selected_analysts=["market"], debug=False, config=config)
     final_state, decision = graph.propagate("AAPL", "2024-06-30")
@@ -43,8 +50,15 @@ def test_trading_graph_propagate_returns_buy_signal(mock_runtime, tmp_path):
         ("openrouter", "gpt-4o-mini", "gpt-4o-mini", "https://openrouter.ai/api/v1"),
     ],
 )
+@pytest.mark.parametrize("use_new_runtime", [False, True])
 def test_trading_graph_supports_multiple_llm_providers(
-    mock_runtime, tmp_path, llm_provider, deep_model, quick_model, backend
+    mock_runtime,
+    tmp_path,
+    llm_provider,
+    deep_model,
+    quick_model,
+    backend,
+    use_new_runtime,
 ):
     config = _base_config(
         tmp_path,
@@ -53,6 +67,7 @@ def test_trading_graph_supports_multiple_llm_providers(
         quick_think_llm=quick_model,
         backend_url=backend,
         online_tools=False,
+        use_new_runtime=use_new_runtime,
     )
 
     graph = TradingAgentsGraph(selected_analysts=["market"], debug=False, config=config)
@@ -72,8 +87,15 @@ def test_trading_graph_supports_multiple_llm_providers(
     ],
 )
 @pytest.mark.parametrize("online_tools", [False, True])
-def test_trading_graph_handles_analyst_permutations(mock_runtime, tmp_path, analysts, online_tools):
-    config = _base_config(tmp_path, online_tools=online_tools)
+@pytest.mark.parametrize("use_new_runtime", [False, True])
+def test_trading_graph_handles_analyst_permutations(
+    mock_runtime, tmp_path, analysts, online_tools, use_new_runtime
+):
+    config = _base_config(
+        tmp_path,
+        online_tools=online_tools,
+        use_new_runtime=use_new_runtime,
+    )
 
     graph = TradingAgentsGraph(selected_analysts=analysts, debug=False, config=config)
     final_state, decision = graph.propagate("GOOGL", "2024-07-02")
@@ -84,8 +106,15 @@ def test_trading_graph_handles_analyst_permutations(mock_runtime, tmp_path, anal
 
 
 @pytest.mark.e2e
-def test_trading_graph_debug_mode_uses_stream(mock_runtime, tmp_path):
-    config = _base_config(tmp_path, online_tools=False)
+@pytest.mark.parametrize("use_new_runtime", [False, True])
+def test_trading_graph_debug_mode_uses_stream(
+    mock_runtime, tmp_path, use_new_runtime
+):
+    config = _base_config(
+        tmp_path,
+        online_tools=False,
+        use_new_runtime=use_new_runtime,
+    )
 
     graph = TradingAgentsGraph(selected_analysts=["market"], debug=True, config=config)
     final_state, decision = graph.propagate("AMZN", "2024-07-03")

--- a/tests/infrastructure/test_external_api_gateway.py
+++ b/tests/infrastructure/test_external_api_gateway.py
@@ -1,0 +1,95 @@
+from collections import deque
+
+import pytest
+
+from tradingagents.infrastructure.external import (
+    ExternalApiGateway,
+    ProviderInvocationError,
+    ProviderNotRegisteredError,
+    build_default_gateway,
+)
+
+
+class RecordingAdapter:
+    def __init__(self, responses):
+        self.responses = deque(responses)
+        self.calls = []
+
+    def invoke(self, operation, payload=None, *, timeout=None):
+        self.calls.append({
+            "operation": operation,
+            "payload": payload,
+            "timeout": timeout,
+        })
+        outcome = self.responses.popleft()
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+
+def test_invoke_success_returns_adapter_response():
+    adapter = RecordingAdapter([{"data": 42}])
+    gateway = ExternalApiGateway({"stub": adapter}, default_timeout=5.0, max_retries=0)
+
+    result = gateway.invoke("stub", "fetch", {"ticker": "AAPL"})
+
+    assert result == {"data": 42}
+    assert adapter.calls[0]["payload"] == {"ticker": "AAPL"}
+    assert adapter.calls[0]["timeout"] == 5.0
+
+
+def test_invoke_respects_override_timeout():
+    adapter = RecordingAdapter(["ok"])
+    gateway = ExternalApiGateway({"stub": adapter}, default_timeout=10.0, max_retries=0)
+
+    gateway.invoke("stub", "fetch", {}, timeout=1.5)
+
+    assert adapter.calls[0]["timeout"] == 1.5
+
+
+def test_invoke_retries_until_success():
+    adapter = RecordingAdapter([RuntimeError("boom"), {"status": "ok"}])
+    gateway = ExternalApiGateway({"stub": adapter}, max_retries=1)
+
+    result = gateway.invoke("stub", "fetch", {})
+
+    assert result == {"status": "ok"}
+    assert len(adapter.calls) == 2
+
+
+def test_invoke_raises_after_max_retries():
+    error = RuntimeError("failure")
+    adapter = RecordingAdapter([error, error, error])
+    gateway = ExternalApiGateway({"stub": adapter}, max_retries=2)
+
+    with pytest.raises(ProviderInvocationError) as excinfo:
+        gateway.invoke("stub", "fetch", {"ticker": "TSLA"})
+
+    assert excinfo.value.provider == "stub"
+    assert excinfo.value.operation == "fetch"
+    assert excinfo.value.attempts == 3
+    assert isinstance(excinfo.value.last_error, RuntimeError)
+
+
+def test_invoke_requires_registered_provider():
+    gateway = ExternalApiGateway()
+
+    with pytest.raises(ProviderNotRegisteredError):
+        gateway.invoke("unknown", "fetch", {})
+
+
+def test_build_default_gateway_registers_stub_providers():
+    gateway = build_default_gateway()
+
+    providers = set(gateway.available_providers())
+
+    assert providers == {
+        "anthropic",
+        "finnhub",
+        "google",
+        "offline_cache",
+        "openai",
+        "reddit",
+        "simfin",
+        "yahoo_finance",
+    }

--- a/tradingagents/agents/utils/agent_utils.py
+++ b/tradingagents/agents/utils/agent_utils.py
@@ -1,9 +1,10 @@
-from langchain_core.messages import BaseMessage, HumanMessage, ToolMessage, AIMessage
-from typing import List
-from typing import Annotated
+from __future__ import annotations
+
+from typing import Annotated, List, Optional, TYPE_CHECKING
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
 from langchain_core.messages import RemoveMessage
 from langchain_core.tools import tool
+from langchain_core.messages import BaseMessage, HumanMessage, ToolMessage, AIMessage
 from datetime import date, timedelta, datetime
 import functools
 import pandas as pd
@@ -13,6 +14,9 @@ from langchain_openai import ChatOpenAI
 import tradingagents.dataflows.interface as interface
 from tradingagents.default_config import DEFAULT_CONFIG
 from langchain_core.messages import HumanMessage
+
+if TYPE_CHECKING:
+    from tradingagents.infrastructure.external import ExternalApiGateway
 
 
 def create_msg_delete():
@@ -44,9 +48,16 @@ class Toolkit:
         """Access the configuration."""
         return self._config
 
-    def __init__(self, config=None):
+    def __init__(self, config=None, gateway: Optional["ExternalApiGateway"] = None):
         if config:
             self.update_config(config)
+        self._gateway = gateway
+
+    @property
+    def gateway(self) -> Optional["ExternalApiGateway"]:
+        """Return the external API gateway associated with this toolkit, if any."""
+
+        return self._gateway
 
     @staticmethod
     @tool

--- a/tradingagents/application/__init__.py
+++ b/tradingagents/application/__init__.py
@@ -1,0 +1,25 @@
+"""Application-layer orchestration components for TradingAgents."""
+
+from .bootstrap.bootstrapper import (
+    BootstrapFailure,
+    DataBootstrapper,
+    default_fetch_nodes,
+)
+from .executor import ExecutionRecord, NodeExecutionError, NodeExecutor
+from .planner import CycleDetectedError, DependencyPlanner, PlanningError, UnresolvableDependencyError
+from .session import SessionResult, TradingSession
+
+__all__ = [
+    "BootstrapFailure",
+    "DataBootstrapper",
+    "default_fetch_nodes",
+    "ExecutionRecord",
+    "NodeExecutionError",
+    "NodeExecutor",
+    "PlanningError",
+    "UnresolvableDependencyError",
+    "CycleDetectedError",
+    "DependencyPlanner",
+    "SessionResult",
+    "TradingSession",
+]

--- a/tradingagents/application/bootstrap/__init__.py
+++ b/tradingagents/application/bootstrap/__init__.py
@@ -1,0 +1,5 @@
+"""Bootstrapper utilities for seeding session data."""
+
+from .bootstrapper import BootstrapFailure, DataBootstrapper, default_fetch_nodes
+
+__all__ = ["BootstrapFailure", "DataBootstrapper", "default_fetch_nodes"]

--- a/tradingagents/application/bootstrap/bootstrapper.py
+++ b/tradingagents/application/bootstrap/bootstrapper.py
@@ -1,0 +1,106 @@
+"""Bootstrap raw session data via dedicated fetch nodes."""
+from __future__ import annotations
+
+from typing import Iterable, Mapping
+
+from tradingagents.application.nodes.data_fetch import DataFetchNode, default_data_fetch_nodes
+from tradingagents.domain import (
+    DuplicateArtifactError,
+    SessionDataContext,
+)
+from tradingagents.infrastructure.external import ExternalApiGateway
+
+__all__ = ["BootstrapFailure", "DataBootstrapper", "default_fetch_nodes"]
+
+
+class BootstrapFailure(RuntimeError):
+    """Raised when the bootstrapper cannot produce required session artifacts."""
+
+    def __init__(self, node_id: str, message: str, *, cause: Exception | None = None) -> None:
+        super().__init__(message)
+        self.node_id = node_id
+        self.cause = cause
+        if cause is not None:
+            self.__cause__ = cause
+
+
+class DataBootstrapper:
+    """Fetches and publishes raw session data before node execution."""
+
+    METADATA_NODE_ID = "bootstrap.metadata"
+
+    def __init__(self, fetch_nodes: Iterable[DataFetchNode] | None = None) -> None:
+        self._fetch_nodes = tuple(fetch_nodes or default_data_fetch_nodes())
+
+    @property
+    def fetch_nodes(self) -> tuple[DataFetchNode, ...]:
+        return self._fetch_nodes
+
+    def bootstrap(
+        self,
+        context: SessionDataContext,
+        gateway: ExternalApiGateway,
+        *,
+        ticker: str,
+        as_of: str,
+    ) -> Mapping[str, object]:
+        """Run the bootstrap flow and return the published artifacts."""
+
+        self._ensure_session_metadata(context, ticker=ticker, as_of=as_of)
+        published: dict[str, object] = {}
+
+        for node in self._fetch_nodes:
+            if not context.is_ready(node.requires):
+                missing = sorted(req for req in node.requires if req not in context)
+                raise BootstrapFailure(
+                    node.id,
+                    f"Missing prerequisites for {node.id}: {', '.join(missing)}",
+                )
+            try:
+                outputs = node.execute(context, gateway)
+            except Exception as exc:  # pragma: no cover - wrapped below
+                raise BootstrapFailure(node.id, "Failed to fetch data", cause=exc) from exc
+
+            for key, value in outputs.items():
+                if key in context:
+                    continue
+                try:
+                    context.publish(key, value)
+                except DuplicateArtifactError:
+                    continue
+                published[key] = value
+
+        return published
+
+    def _ensure_session_metadata(
+        self,
+        context: SessionDataContext,
+        *,
+        ticker: str,
+        as_of: str,
+    ) -> None:
+        if "session.ticker" in context:
+            existing = context.require("session.ticker")
+            if existing != ticker:
+                raise BootstrapFailure(
+                    self.METADATA_NODE_ID,
+                    f"Session ticker '{existing}' does not match bootstrap request '{ticker}'.",
+                )
+        else:
+            context.publish("session.ticker", ticker)
+
+        if "session.as_of" in context:
+            existing = context.require("session.as_of")
+            if existing != as_of:
+                raise BootstrapFailure(
+                    self.METADATA_NODE_ID,
+                    f"Session as_of '{existing}' does not match bootstrap request '{as_of}'.",
+                )
+        else:
+            context.publish("session.as_of", as_of)
+
+
+def default_fetch_nodes() -> tuple[DataFetchNode, ...]:
+    """Expose the default fetch node factory for consumers."""
+
+    return tuple(default_data_fetch_nodes())

--- a/tradingagents/application/executor.py
+++ b/tradingagents/application/executor.py
@@ -1,0 +1,65 @@
+"""Node execution engine with basic retry semantics."""
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Iterable, List
+
+from tradingagents.domain import DuplicateArtifactError, NodeSpec, SessionDataContext
+
+__all__ = ["NodeExecutionError", "ExecutionRecord", "NodeExecutor"]
+
+
+@dataclass(frozen=True)
+class NodeExecutionError(RuntimeError):
+    node_id: str
+    attempts: int
+    cause: Exception
+
+    def __str__(self) -> str:  # pragma: no cover - formatting helper
+        return f"Node '{self.node_id}' failed after {self.attempts} attempts: {self.cause}"
+
+
+@dataclass
+class ExecutionRecord:
+    node_id: str
+    attempts: int
+    duration: float
+
+
+class NodeExecutor:
+    """Execute nodes produced by the planner and record basic metrics."""
+
+    def __init__(self, *, max_retries: int = 0) -> None:
+        self.max_retries = max_retries
+
+    def execute(
+        self,
+        plan: Iterable[NodeSpec],
+        context: SessionDataContext,
+        gateway: object,
+    ) -> List[ExecutionRecord]:
+        records: List[ExecutionRecord] = []
+        for spec in plan:
+            node = spec.instantiate()
+            attempts = 0
+            start = time.perf_counter()
+            while True:
+                attempts += 1
+                try:
+                    outputs = node.execute(context, gateway)
+                except Exception as exc:  # pragma: no cover - exercised via tests
+                    if attempts > self.max_retries:
+                        raise NodeExecutionError(spec.id, attempts, exc) from exc
+                    continue
+                for key, value in outputs.items():
+                    if key in context:
+                        continue
+                    try:
+                        context.publish(key, value)
+                    except DuplicateArtifactError:
+                        continue
+                duration = time.perf_counter() - start
+                records.append(ExecutionRecord(spec.id, attempts, duration))
+                break
+        return records

--- a/tradingagents/application/nodes/__init__.py
+++ b/tradingagents/application/nodes/__init__.py
@@ -1,0 +1,141 @@
+"""Graph node implementations for the application layer."""
+
+from __future__ import annotations
+
+from tradingagents.domain import NodeKind, NodeSpec
+
+from .data_fetch import (
+    DataFetchNode,
+    FundamentalsDataFetchNode,
+    MarketDataFetchNode,
+    NewsDataFetchNode,
+    SentimentDataFetchNode,
+    default_data_fetch_nodes,
+)
+from .analysis import (
+    FundamentalsAnalysisNode,
+    MarketAnalysisNode,
+    NewsAnalysisNode,
+    SentimentAnalysisNode,
+)
+from .debate import (
+    BearResearchNode,
+    BullResearchNode,
+    RiskAssessmentNode,
+    TraderDecisionNode,
+)
+
+__all__ = [
+    "DataFetchNode",
+    "FundamentalsDataFetchNode",
+    "MarketDataFetchNode",
+    "NewsDataFetchNode",
+    "SentimentDataFetchNode",
+    "default_data_fetch_nodes",
+    "FundamentalsAnalysisNode",
+    "MarketAnalysisNode",
+    "NewsAnalysisNode",
+    "SentimentAnalysisNode",
+    "BearResearchNode",
+    "BullResearchNode",
+    "TraderDecisionNode",
+    "RiskAssessmentNode",
+    "default_node_specs",
+]
+
+
+def default_node_specs() -> list[NodeSpec]:
+    """Return the default application node specs used by the planner."""
+
+    return [
+        NodeSpec(
+            id="analysis.market",
+            node_kind=NodeKind.ANALYSIS,
+            requires=frozenset({"session.ticker", "session.as_of", "raw.market"}),
+            produces=frozenset({"analysis.market_report"}),
+            factory=MarketAnalysisNode,
+        ),
+        NodeSpec(
+            id="analysis.news",
+            node_kind=NodeKind.ANALYSIS,
+            requires=frozenset({"session.ticker", "session.as_of", "raw.news"}),
+            produces=frozenset({"analysis.news_report"}),
+            factory=NewsAnalysisNode,
+        ),
+        NodeSpec(
+            id="analysis.fundamentals",
+            node_kind=NodeKind.ANALYSIS,
+            requires=frozenset({"session.ticker", "session.as_of", "raw.fundamentals"}),
+            produces=frozenset({"analysis.fundamentals_report"}),
+            factory=FundamentalsAnalysisNode,
+        ),
+        NodeSpec(
+            id="analysis.sentiment",
+            node_kind=NodeKind.ANALYSIS,
+            requires=frozenset({"session.ticker", "session.as_of", "raw.sentiment"}),
+            produces=frozenset({"analysis.sentiment_report"}),
+            factory=SentimentAnalysisNode,
+        ),
+        NodeSpec(
+            id="debate.bull",
+            node_kind=NodeKind.DEBATE,
+            requires=frozenset(
+                {
+                    "session.ticker",
+                    "session.as_of",
+                    "analysis.market_report",
+                    "analysis.news_report",
+                    "analysis.fundamentals_report",
+                    "analysis.sentiment_report",
+                }
+            ),
+            produces=frozenset({"debate.bull_case"}),
+            factory=BullResearchNode,
+        ),
+        NodeSpec(
+            id="debate.bear",
+            node_kind=NodeKind.DEBATE,
+            requires=frozenset(
+                {
+                    "session.ticker",
+                    "session.as_of",
+                    "analysis.market_report",
+                    "analysis.news_report",
+                    "analysis.fundamentals_report",
+                    "analysis.sentiment_report",
+                }
+            ),
+            produces=frozenset({"debate.bear_case"}),
+            factory=BearResearchNode,
+        ),
+        NodeSpec(
+            id="decision.trader",
+            node_kind=NodeKind.DECISION,
+            requires=frozenset(
+                {
+                    "session.ticker",
+                    "session.as_of",
+                    "debate.bull_case",
+                    "debate.bear_case",
+                    "analysis.market_report",
+                }
+            ),
+            produces=frozenset({"decision.trader_plan"}),
+            factory=TraderDecisionNode,
+        ),
+        NodeSpec(
+            id="risk.assessment",
+            node_kind=NodeKind.RISK,
+            requires=frozenset(
+                {
+                    "session.ticker",
+                    "session.as_of",
+                    "decision.trader_plan",
+                    "analysis.news_report",
+                    "analysis.fundamentals_report",
+                }
+            ),
+            produces=frozenset({"risk.assessment"}),
+            factory=RiskAssessmentNode,
+        ),
+    ]

--- a/tradingagents/application/nodes/analysis.py
+++ b/tradingagents/application/nodes/analysis.py
@@ -1,0 +1,109 @@
+"""Analysis nodes that transform raw data into structured reports."""
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from tradingagents.domain import NodeKind, SessionDataContext
+
+from .data_fetch import DataFetchNode
+
+__all__ = [
+    "MarketAnalysisNode",
+    "NewsAnalysisNode",
+    "FundamentalsAnalysisNode",
+    "SentimentAnalysisNode",
+]
+
+
+class _BaseAnalysisNode(DataFetchNode):
+    provider = "openai"
+
+    def __init__(
+        self,
+        node_id: str,
+        operation: str,
+        produces_key: str,
+        *,
+        extra_requires: set[str] | None = None,
+    ) -> None:
+        super().__init__(
+            node_id=node_id,
+            provider=self.provider,
+            operation=operation,
+            produces_key=produces_key,
+            extra_requires=extra_requires,
+        )
+        self.node_kind = NodeKind.ANALYSIS
+
+    def build_payload(self, context: SessionDataContext) -> Mapping[str, Any]:
+        payload = super().build_payload(context)
+        payload["context"] = "analysis"
+        return payload
+
+    def transform_response(self, response: Mapping[str, Any]) -> Any:
+        return response.get("report", response)
+
+    def execute(self, context: SessionDataContext, gateway: object) -> Mapping[str, Any]:
+        payload = self.build_payload(context)
+        response = gateway.invoke(self.provider, self.operation, payload)
+        return {self._produces_key: self.transform_response(response)}
+
+
+class MarketAnalysisNode(_BaseAnalysisNode):
+    def __init__(self) -> None:
+        super().__init__(
+            node_id="analysis.market",
+            operation="analyze_market",
+            produces_key="analysis.market_report",
+            extra_requires={"raw.market"},
+        )
+
+    def build_payload(self, context: SessionDataContext) -> Mapping[str, Any]:
+        payload = dict(super().build_payload(context))
+        payload["market_data"] = context.require("raw.market")
+        return payload
+
+
+class NewsAnalysisNode(_BaseAnalysisNode):
+    def __init__(self) -> None:
+        super().__init__(
+            node_id="analysis.news",
+            operation="analyze_news",
+            produces_key="analysis.news_report",
+            extra_requires={"raw.news"},
+        )
+
+    def build_payload(self, context: SessionDataContext) -> Mapping[str, Any]:
+        payload = dict(super().build_payload(context))
+        payload["news_items"] = context.require("raw.news")
+        return payload
+
+
+class FundamentalsAnalysisNode(_BaseAnalysisNode):
+    def __init__(self) -> None:
+        super().__init__(
+            node_id="analysis.fundamentals",
+            operation="analyze_fundamentals",
+            produces_key="analysis.fundamentals_report",
+            extra_requires={"raw.fundamentals"},
+        )
+
+    def build_payload(self, context: SessionDataContext) -> Mapping[str, Any]:
+        payload = dict(super().build_payload(context))
+        payload["fundamentals"] = context.require("raw.fundamentals")
+        return payload
+
+
+class SentimentAnalysisNode(_BaseAnalysisNode):
+    def __init__(self) -> None:
+        super().__init__(
+            node_id="analysis.sentiment",
+            operation="analyze_sentiment",
+            produces_key="analysis.sentiment_report",
+            extra_requires={"raw.sentiment"},
+        )
+
+    def build_payload(self, context: SessionDataContext) -> Mapping[str, Any]:
+        payload = dict(super().build_payload(context))
+        payload["sentiment"] = context.require("raw.sentiment")
+        return payload

--- a/tradingagents/application/nodes/data_fetch.py
+++ b/tradingagents/application/nodes/data_fetch.py
@@ -1,0 +1,132 @@
+"""Data fetch nodes that seed the session context with raw artifacts."""
+from __future__ import annotations
+
+from typing import Any, Iterable, Mapping
+
+from tradingagents.domain import GraphNode, NodeKind, SessionDataContext
+
+__all__ = [
+    "DataFetchNode",
+    "MarketDataFetchNode",
+    "NewsDataFetchNode",
+    "FundamentalsDataFetchNode",
+    "SentimentDataFetchNode",
+    "default_data_fetch_nodes",
+]
+
+
+class DataFetchNode(GraphNode):
+    """Base implementation for nodes that retrieve raw datasets."""
+
+    base_requirements = frozenset({"session.ticker", "session.as_of"})
+
+    def __init__(
+        self,
+        node_id: str,
+        provider: str,
+        operation: str,
+        produces_key: str,
+        *,
+        extra_requires: Iterable[str] | None = None,
+    ) -> None:
+        self.id = node_id
+        self.provider = provider
+        self.operation = operation
+        self.node_kind = NodeKind.DATA_FETCH
+        self._produces_key = produces_key
+        requirements = set(self.base_requirements)
+        if extra_requires:
+            requirements.update(extra_requires)
+        self.requires = frozenset(requirements)
+        self.produces = frozenset({produces_key})
+
+    def build_payload(self, context: SessionDataContext) -> Mapping[str, Any]:
+        """Construct the payload passed to the gateway."""
+
+        return {
+            "ticker": context.require("session.ticker"),
+            "as_of": context.require("session.as_of"),
+        }
+
+    def execute(self, context: SessionDataContext, gateway: object) -> Mapping[str, Any]:
+        payload = self.build_payload(context)
+        response = gateway.invoke(self.provider, self.operation, payload)
+        return {self._produces_key: response}
+
+
+class MarketDataFetchNode(DataFetchNode):
+    """Fetch historical market data for the session ticker."""
+
+    def __init__(self, lookback_days: int = 30) -> None:
+        self.lookback_days = lookback_days
+        super().__init__(
+            node_id="data.fetch.market",
+            provider="yahoo_finance",
+            operation="historical_prices",
+            produces_key="raw.market",
+        )
+
+    def build_payload(self, context: SessionDataContext) -> Mapping[str, Any]:
+        payload = dict(super().build_payload(context))
+        payload["window_days"] = self.lookback_days
+        return payload
+
+
+class NewsDataFetchNode(DataFetchNode):
+    """Fetch recent company news from market data providers."""
+
+    def __init__(self, window_days: int = 7, limit: int = 20) -> None:
+        self.window_days = window_days
+        self.limit = limit
+        super().__init__(
+            node_id="data.fetch.news",
+            provider="finnhub",
+            operation="company_news",
+            produces_key="raw.news",
+        )
+
+    def build_payload(self, context: SessionDataContext) -> Mapping[str, Any]:
+        payload = dict(super().build_payload(context))
+        payload.update({"window_days": self.window_days, "limit": self.limit})
+        return payload
+
+
+class FundamentalsDataFetchNode(DataFetchNode):
+    """Fetch fundamentals snapshot from financial statement providers."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            node_id="data.fetch.fundamentals",
+            provider="simfin",
+            operation="fundamentals_snapshot",
+            produces_key="raw.fundamentals",
+        )
+
+
+class SentimentDataFetchNode(DataFetchNode):
+    """Fetch social sentiment signals for the current ticker."""
+
+    def __init__(self, window_days: int = 3) -> None:
+        self.window_days = window_days
+        super().__init__(
+            node_id="data.fetch.sentiment",
+            provider="reddit",
+            operation="social_sentiment",
+            produces_key="raw.sentiment",
+        )
+
+    def build_payload(self, context: SessionDataContext) -> Mapping[str, Any]:
+        payload = dict(super().build_payload(context))
+        payload["window_days"] = self.window_days
+        return payload
+
+
+def default_data_fetch_nodes() -> list[DataFetchNode]:
+    """Return the default set of fetch nodes used by the bootstrapper."""
+
+    return [
+        MarketDataFetchNode(),
+        NewsDataFetchNode(),
+        FundamentalsDataFetchNode(),
+        SentimentDataFetchNode(),
+    ]

--- a/tradingagents/application/nodes/debate.py
+++ b/tradingagents/application/nodes/debate.py
@@ -1,0 +1,152 @@
+"""Debate and decision nodes built on top of analysis outputs."""
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from tradingagents.domain import NodeKind, SessionDataContext
+
+from .data_fetch import DataFetchNode
+
+__all__ = [
+    "BullResearchNode",
+    "BearResearchNode",
+    "TraderDecisionNode",
+    "RiskAssessmentNode",
+]
+
+
+class _BaseDebateNode(DataFetchNode):
+    provider = "openai"
+
+    def __init__(
+        self,
+        node_id: str,
+        operation: str,
+        produces_key: str,
+        node_kind: NodeKind,
+        requires: set[str],
+    ) -> None:
+        super().__init__(
+            node_id=node_id,
+            provider=self.provider,
+            operation=operation,
+            produces_key=produces_key,
+            extra_requires=requires,
+        )
+        self.node_kind = node_kind
+
+    def build_payload(self, context: SessionDataContext) -> Mapping[str, Any]:
+        return {
+            "ticker": context.require("session.ticker"),
+            "as_of": context.require("session.as_of"),
+        }
+
+    def extract_output(self, response: Mapping[str, Any]) -> Any:
+        return response.get("content", response)
+
+    def execute(self, context: SessionDataContext, gateway: object) -> Mapping[str, Any]:
+        payload = dict(self.build_payload(context))
+        payload.update(self.additional_payload(context))
+        response = gateway.invoke(self.provider, self.operation, payload)
+        return {self._produces_key: self.extract_output(response)}
+
+    def additional_payload(self, context: SessionDataContext) -> Mapping[str, Any]:
+        return {}
+
+
+class BullResearchNode(_BaseDebateNode):
+    def __init__(self) -> None:
+        super().__init__(
+            node_id="debate.bull",
+            operation="compose_bull_case",
+            produces_key="debate.bull_case",
+            node_kind=NodeKind.DEBATE,
+            requires={
+                "analysis.market_report",
+                "analysis.news_report",
+                "analysis.fundamentals_report",
+                "analysis.sentiment_report",
+            },
+        )
+
+    def additional_payload(self, context: SessionDataContext) -> Mapping[str, Any]:
+        return {
+            "market_report": context.require("analysis.market_report"),
+            "news_report": context.require("analysis.news_report"),
+            "fundamentals_report": context.require("analysis.fundamentals_report"),
+            "sentiment_report": context.require("analysis.sentiment_report"),
+        }
+
+
+class BearResearchNode(_BaseDebateNode):
+    def __init__(self) -> None:
+        super().__init__(
+            node_id="debate.bear",
+            operation="compose_bear_case",
+            produces_key="debate.bear_case",
+            node_kind=NodeKind.DEBATE,
+            requires={
+                "analysis.market_report",
+                "analysis.news_report",
+                "analysis.fundamentals_report",
+                "analysis.sentiment_report",
+            },
+        )
+
+    def additional_payload(self, context: SessionDataContext) -> Mapping[str, Any]:
+        return {
+            "market_report": context.require("analysis.market_report"),
+            "news_report": context.require("analysis.news_report"),
+            "fundamentals_report": context.require("analysis.fundamentals_report"),
+            "sentiment_report": context.require("analysis.sentiment_report"),
+        }
+
+
+class TraderDecisionNode(_BaseDebateNode):
+    def __init__(self) -> None:
+        super().__init__(
+            node_id="decision.trader",
+            operation="draft_trader_plan",
+            produces_key="decision.trader_plan",
+            node_kind=NodeKind.DECISION,
+            requires={
+                "debate.bull_case",
+                "debate.bear_case",
+                "analysis.market_report",
+            },
+        )
+
+    def additional_payload(self, context: SessionDataContext) -> Mapping[str, Any]:
+        return {
+            "bull_case": context.require("debate.bull_case"),
+            "bear_case": context.require("debate.bear_case"),
+            "market_report": context.require("analysis.market_report"),
+        }
+
+    def extract_output(self, response: Mapping[str, Any]) -> Any:
+        return response.get("plan", response)
+
+
+class RiskAssessmentNode(_BaseDebateNode):
+    def __init__(self) -> None:
+        super().__init__(
+            node_id="risk.assessment",
+            operation="assess_risk",
+            produces_key="risk.assessment",
+            node_kind=NodeKind.RISK,
+            requires={
+                "decision.trader_plan",
+                "analysis.news_report",
+                "analysis.fundamentals_report",
+            },
+        )
+
+    def additional_payload(self, context: SessionDataContext) -> Mapping[str, Any]:
+        return {
+            "trader_plan": context.require("decision.trader_plan"),
+            "news_report": context.require("analysis.news_report"),
+            "fundamentals_report": context.require("analysis.fundamentals_report"),
+        }
+
+    def extract_output(self, response: Mapping[str, Any]) -> Any:
+        return response.get("assessment", response)

--- a/tradingagents/application/planner.py
+++ b/tradingagents/application/planner.py
@@ -1,0 +1,76 @@
+"""Dependency planning for GraphNode execution."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Set
+
+from tradingagents.domain import NodeSpec, SessionDataContext
+
+__all__ = [
+    "PlanningError",
+    "UnresolvableDependencyError",
+    "CycleDetectedError",
+    "DependencyPlanner",
+]
+
+
+class PlanningError(RuntimeError):
+    """Base class for planning-related failures."""
+
+
+@dataclass(frozen=True)
+class UnresolvableDependencyError(PlanningError):
+    node_id: str
+    missing_keys: Set[str]
+
+    def __str__(self) -> str:  # pragma: no cover - simple formatting
+        keys = ", ".join(sorted(self.missing_keys))
+        return f"Node '{self.node_id}' depends on unknown artifacts: {keys}."
+
+
+@dataclass(frozen=True)
+class CycleDetectedError(PlanningError):
+    remaining_nodes: Set[str]
+
+    def __str__(self) -> str:  # pragma: no cover - simple formatting
+        nodes = ", ".join(sorted(self.remaining_nodes))
+        return f"Circular dependency detected among nodes: {nodes}."
+
+
+class DependencyPlanner:
+    """Build a deterministic execution plan based on node dependencies."""
+
+    def __init__(self, node_specs: Iterable[NodeSpec]) -> None:
+        specs = list(node_specs)
+        self._spec_map: Dict[str, NodeSpec] = {}
+        for spec in specs:
+            if spec.id in self._spec_map:
+                raise ValueError(f"Duplicate NodeSpec id detected: {spec.id}")
+            self._spec_map[spec.id] = spec
+
+    def plan(self, context: SessionDataContext) -> List[NodeSpec]:
+        available_keys = set(context.snapshot().keys())
+        remaining = dict(self._spec_map)
+
+        # Validate that every requirement can be satisfied by either the context or a node.
+        producible_keys = available_keys | {
+            key for spec in remaining.values() for key in spec.produces
+        }
+        for spec in list(remaining.values()):
+            missing = spec.requires - producible_keys
+            if missing:
+                raise UnresolvableDependencyError(spec.id, missing)
+
+        plan: List[NodeSpec] = []
+        while remaining:
+            ready = [
+                spec for spec in remaining.values() if spec.requires <= available_keys
+            ]
+            if not ready:
+                raise CycleDetectedError(set(remaining))
+            ready.sort(key=lambda spec: spec.id)
+            for spec in ready:
+                plan.append(spec)
+                available_keys.update(spec.produces)
+                remaining.pop(spec.id, None)
+        return plan

--- a/tradingagents/application/session.py
+++ b/tradingagents/application/session.py
@@ -1,0 +1,72 @@
+"""High-level TradingSession facade for the modern runtime."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Sequence
+
+from tradingagents.application.bootstrap import DataBootstrapper
+from tradingagents.application.executor import ExecutionRecord, NodeExecutor
+from tradingagents.application.nodes import default_node_specs
+from tradingagents.application.planner import DependencyPlanner
+from tradingagents.domain import SessionDataContext
+from tradingagents.infrastructure.external import ExternalApiGateway
+
+__all__ = ["SessionResult", "TradingSession"]
+
+
+@dataclass
+class SessionResult:
+    context: SessionDataContext
+    executed_nodes: Sequence[ExecutionRecord]
+    plan: Sequence[str]
+
+
+class TradingSession:
+    """Coordinates bootstrapping, planning, and node execution."""
+
+    def __init__(
+        self,
+        *,
+        bootstrapper: DataBootstrapper | None = None,
+        planner: DependencyPlanner | None = None,
+        executor: NodeExecutor | None = None,
+        gateway: ExternalApiGateway | None = None,
+        node_specs: Iterable = (),
+    ) -> None:
+        self.bootstrapper = bootstrapper or DataBootstrapper()
+        self.gateway = gateway
+        self._provided_specs = list(node_specs)
+        self._planner = planner
+        self._executor = executor
+
+    def run(
+        self,
+        *,
+        ticker: str,
+        as_of: str,
+        context: SessionDataContext | None = None,
+    ) -> SessionResult:
+        runtime_context = context or SessionDataContext()
+        gateway = self.gateway
+        if gateway is None:
+            raise ValueError("TradingSession requires an ExternalApiGateway instance.")
+
+        self.bootstrapper.bootstrap(
+            runtime_context,
+            gateway,
+            ticker=ticker,
+            as_of=as_of,
+        )
+
+        specs = self._provided_specs or default_node_specs()
+        planner = self._planner or DependencyPlanner(specs)
+        plan = planner.plan(runtime_context)
+
+        executor = self._executor or NodeExecutor()
+        records = executor.execute(plan, runtime_context, gateway)
+
+        return SessionResult(
+            context=runtime_context,
+            executed_nodes=records,
+            plan=[spec.id for spec in plan],
+        )

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -4,10 +4,14 @@ import os
 def _env_flag(name: str, default: str = "false") -> bool:
     return os.getenv(name, default).strip().lower() in {"1", "true", "yes", "on"}
 
+_PACKAGE_DIR = os.path.abspath(os.path.dirname(__file__))
+_REPO_ROOT = os.path.abspath(os.path.join(_PACKAGE_DIR, ".."))
+
 DEFAULT_CONFIG = {
     "project_dir": os.path.abspath(os.path.join(os.path.dirname(__file__), ".")),
     "results_dir": os.getenv("TRADINGAGENTS_RESULTS_DIR", "./results"),
-    "data_dir": "/Users/yluo/Documents/Code/ScAI/FR1-data",
+    # Allow overriding data root via env; default to <repo_root>/data
+    "data_dir": os.getenv("TRADINGAGENTS_DATA_DIR", os.path.join(_REPO_ROOT, "data")),
     "data_cache_dir": os.path.join(
         os.path.abspath(os.path.join(os.path.dirname(__file__), ".")),
         "dataflows/data_cache",

--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -1,5 +1,9 @@
 import os
 
+
+def _env_flag(name: str, default: str = "false") -> bool:
+    return os.getenv(name, default).strip().lower() in {"1", "true", "yes", "on"}
+
 DEFAULT_CONFIG = {
     "project_dir": os.path.abspath(os.path.join(os.path.dirname(__file__), ".")),
     "results_dir": os.getenv("TRADINGAGENTS_RESULTS_DIR", "./results"),
@@ -19,4 +23,11 @@ DEFAULT_CONFIG = {
     "max_recur_limit": 100,
     # Tool settings
     "online_tools": True,
+    # External API gateway defaults
+    "gateway_default_timeout": 30.0,
+    "gateway_max_retries": 2,
+    "gateway_retry_backoff_seconds": 0.0,
+    # Feature flags
+    "use_data_bootstrapper": _env_flag("USE_DATA_BOOTSTRAPPER"),
+    "use_new_runtime": _env_flag("USE_NEW_RUNTIME"),
 }

--- a/tradingagents/domain/__init__.py
+++ b/tradingagents/domain/__init__.py
@@ -1,0 +1,27 @@
+"""Domain-layer contracts for the modern TradingAgents architecture.
+
+Refer to ``docs-v2/new-architecture/final-architecture.md`` for the
+comprehensive overview of how these abstractions collaborate with the
+application and infrastructure layers.
+"""
+
+from .context.session_data_context import (
+    DuplicateArtifactError,
+    InvalidArtifactNamespaceError,
+    MissingArtifactError,
+    SessionDataContext,
+    validate_artifact_key,
+)
+from .nodes.graph_node import GraphNode, NodeKind
+from .nodes.node_spec import NodeSpec
+
+__all__ = [
+    "DuplicateArtifactError",
+    "InvalidArtifactNamespaceError",
+    "MissingArtifactError",
+    "SessionDataContext",
+    "GraphNode",
+    "NodeKind",
+    "NodeSpec",
+    "validate_artifact_key",
+]

--- a/tradingagents/domain/context/__init__.py
+++ b/tradingagents/domain/context/__init__.py
@@ -1,0 +1,17 @@
+"""Context utilities for sharing artifacts across graph nodes."""
+
+from .session_data_context import (
+    DuplicateArtifactError,
+    InvalidArtifactNamespaceError,
+    MissingArtifactError,
+    SessionDataContext,
+    validate_artifact_key,
+)
+
+__all__ = [
+    "DuplicateArtifactError",
+    "InvalidArtifactNamespaceError",
+    "MissingArtifactError",
+    "SessionDataContext",
+    "validate_artifact_key",
+]

--- a/tradingagents/domain/context/session_data_context.py
+++ b/tradingagents/domain/context/session_data_context.py
@@ -1,0 +1,118 @@
+"""Session-scoped artifact store for the modern TradingAgents runtime.
+
+The :class:`SessionDataContext` is introduced as part of the SOLID-aligned
+architecture outlined in ``docs-v2/new-architecture/final-architecture.md``.
+It provides deterministic data sharing across nodes, preventing accidental
+mutation and making orchestration decisions reproducible.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, Mapping
+
+__all__ = [
+    "DuplicateArtifactError",
+    "InvalidArtifactNamespaceError",
+    "MissingArtifactError",
+    "SessionDataContext",
+    "validate_artifact_key",
+]
+
+
+class SessionDataContextError(RuntimeError):
+    """Base class for context-related issues."""
+
+
+class MissingArtifactError(SessionDataContextError):
+    """Raised when a required artifact has not yet been published."""
+
+    def __init__(self, key: str) -> None:
+        super().__init__(f"Artifact '{key}' is missing from the session context.")
+        self.key = key
+
+
+class DuplicateArtifactError(SessionDataContextError):
+    """Raised when attempting to publish an artifact more than once."""
+
+    def __init__(self, key: str) -> None:
+        super().__init__(f"Artifact '{key}' has already been published.")
+        self.key = key
+
+
+class InvalidArtifactNamespaceError(SessionDataContextError):
+    """Raised when an artifact key does not follow the required namespace rules."""
+
+    def __init__(self, key: str) -> None:
+        super().__init__(
+            "Artifact keys must be namespaced (e.g., 'raw.market')."
+            f" Received: '{key}'."
+        )
+        self.key = key
+
+
+def validate_artifact_key(key: str) -> None:
+    if not isinstance(key, str) or "." not in key:
+        raise InvalidArtifactNamespaceError(str(key))
+    segments = key.split(".")
+    if any(not segment.strip() for segment in segments):
+        raise InvalidArtifactNamespaceError(key)
+
+
+@dataclass(frozen=True)
+class _ContextState:
+    """Immutable snapshot state."""
+
+    artifacts: Dict[str, Any]
+
+
+class SessionDataContext:
+    """Shared store for artifacts exchanged between graph nodes.
+
+    The context enforces namespaced keys (``raw.*``, ``analysis.*`` etc.) and
+    guards against accidental duplicate writes. Nodes obtain their dependencies
+    via :meth:`require` and publish new data with :meth:`publish`.
+    """
+
+    def __init__(self, initial_data: Mapping[str, Any] | None = None) -> None:
+        self._state = _ContextState(artifacts={})
+        if initial_data:
+            for key, value in dict(initial_data).items():
+                validate_artifact_key(key)
+                self._state.artifacts[key] = value
+
+    def require(self, key: str) -> Any:
+        """Return the artifact for ``key`` or raise :class:`MissingArtifactError`."""
+
+        validate_artifact_key(key)
+        try:
+            return self._state.artifacts[key]
+        except KeyError as exc:  # pragma: no cover - exercised via error path
+            raise MissingArtifactError(key) from exc
+
+    def publish(self, key: str, value: Any) -> Any:
+        """Publish ``value`` under ``key`` if it has not been published before."""
+
+        validate_artifact_key(key)
+        if key in self._state.artifacts:
+            raise DuplicateArtifactError(key)
+        self._state.artifacts[key] = value
+        return value
+
+    def is_ready(self, requirements: Iterable[str]) -> bool:
+        """Return ``True`` when every requirement has been published."""
+
+        for key in requirements:
+            if key not in self._state.artifacts:
+                return False
+        return True
+
+    def snapshot(self) -> Dict[str, Any]:
+        """Return a shallow copy of the stored artifacts."""
+
+        return dict(self._state.artifacts)
+
+    def __contains__(self, key: object) -> bool:  # pragma: no cover - simple passthrough
+        return key in self._state.artifacts
+
+    def __repr__(self) -> str:  # pragma: no cover - diagnostic helper
+        return f"SessionDataContext(artifacts={self._state.artifacts!r})"

--- a/tradingagents/domain/nodes/__init__.py
+++ b/tradingagents/domain/nodes/__init__.py
@@ -1,0 +1,6 @@
+"""Node abstractions for the TradingAgents execution graph."""
+
+from .graph_node import GraphNode, NodeKind
+from .node_spec import NodeSpec
+
+__all__ = ["GraphNode", "NodeKind", "NodeSpec"]

--- a/tradingagents/domain/nodes/graph_node.py
+++ b/tradingagents/domain/nodes/graph_node.py
@@ -1,0 +1,51 @@
+"""Graph node protocol used by the modern TradingAgents runtime.
+
+The taxonomy of node kinds and their responsibilities is defined in
+``docs-v2/new-architecture/final-architecture.md``. Nodes interact with the
+shared :class:`~tradingagents.domain.SessionDataContext` to obtain inputs and
+publish outputs.
+"""
+from __future__ import annotations
+
+from enum import Enum
+from typing import Mapping, Protocol, runtime_checkable
+
+from tradingagents.domain.context.session_data_context import SessionDataContext
+
+__all__ = ["GraphNode", "NodeKind"]
+
+
+class NodeKind(str, Enum):
+    """Classification for nodes participating in a trading session."""
+
+    DATA_FETCH = "data_fetch"
+    ANALYSIS = "analysis"
+    AGGREGATION = "aggregation"
+    DEBATE = "debate"
+    RISK = "risk"
+    DECISION = "decision"
+    REPORT = "report"
+
+
+@runtime_checkable
+class GraphNode(Protocol):
+    """Protocol implemented by every node in the execution graph."""
+
+    id: str
+    node_kind: NodeKind
+    requires: frozenset[str]
+    produces: frozenset[str]
+
+    def execute(
+        self,
+        context: SessionDataContext,
+        gateway: object,
+    ) -> Mapping[str, object]:
+        """Execute the node's logic and return published artifacts.
+
+        The ``gateway`` parameter will be an instance of
+        :class:`ExternalApiGateway` (introduced in Story S3). It is typed as
+        ``object`` here to avoid an import cycle before the gateway exists.
+        """
+
+        ...

--- a/tradingagents/domain/nodes/node_spec.py
+++ b/tradingagents/domain/nodes/node_spec.py
@@ -1,0 +1,68 @@
+"""Declarative metadata describing graph nodes for planning and execution."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, Mapping
+
+from tradingagents.domain.context.session_data_context import validate_artifact_key
+from tradingagents.domain.nodes.graph_node import GraphNode, NodeKind
+
+__all__ = ["NodeSpec"]
+
+
+@dataclass(frozen=True, slots=True)
+class NodeSpec:
+    """Metadata and factory used by the planner to construct a node instance."""
+
+    id: str
+    node_kind: NodeKind
+    requires: frozenset[str] = field(default_factory=frozenset)
+    produces: frozenset[str] = field(default_factory=frozenset)
+    factory: Callable[..., GraphNode] | None = None
+    description: str | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "requires", frozenset(self.requires))
+        object.__setattr__(self, "produces", frozenset(self.produces))
+        for key in self.requires | self.produces:
+            validate_artifact_key(key)
+        if not self.id:
+            raise ValueError("NodeSpec.id must be a non-empty string.")
+
+    def instantiate(self, **kwargs) -> GraphNode:
+        """Instantiate the node using the configured factory."""
+
+        if self.factory is None:
+            raise TypeError(f"NodeSpec '{self.id}' does not define a factory.")
+        node = self.factory(**kwargs)
+        if node.id != self.id:
+            raise ValueError(
+                f"Node '{node.id}' does not match NodeSpec id '{self.id}'."
+            )
+        if node.node_kind != self.node_kind:
+            raise ValueError(
+                f"Node '{node.id}' kind {node.node_kind}"
+                f" does not match spec kind {self.node_kind}."
+            )
+        if frozenset(node.requires) != self.requires:
+            raise ValueError(
+                f"Node '{node.id}' requires {node.requires}"
+                f" but spec requires {sorted(self.requires)}."
+            )
+        if frozenset(node.produces) != self.produces:
+            raise ValueError(
+                f"Node '{node.id}' produces {node.produces}"
+                f" but spec expects {sorted(self.produces)}."
+            )
+        return node
+
+    def to_dict(self) -> Mapping[str, object]:
+        """Return a serialisable representation of the node metadata."""
+
+        return {
+            "id": self.id,
+            "node_kind": self.node_kind.value,
+            "requires": sorted(self.requires),
+            "produces": sorted(self.produces),
+            "description": self.description,
+        }

--- a/tradingagents/graph/setup.py
+++ b/tradingagents/graph/setup.py
@@ -1,6 +1,8 @@
 # TradingAgents/graph/setup.py
 
-from typing import Dict, Any
+from __future__ import annotations
+
+from typing import Any, Dict, Optional, TYPE_CHECKING
 from langchain_openai import ChatOpenAI
 from langgraph.graph import END, StateGraph, START
 from langgraph.prebuilt import ToolNode
@@ -8,6 +10,9 @@ from langgraph.prebuilt import ToolNode
 from tradingagents.agents import *
 from tradingagents.agents.utils.agent_states import AgentState
 from tradingagents.agents.utils.agent_utils import Toolkit
+
+if TYPE_CHECKING:
+    from tradingagents.infrastructure.external import ExternalApiGateway
 
 from .conditional_logic import ConditionalLogic
 
@@ -27,6 +32,7 @@ class GraphSetup:
         invest_judge_memory,
         risk_manager_memory,
         conditional_logic: ConditionalLogic,
+        gateway: Optional["ExternalApiGateway"] = None,
     ):
         """Initialize with required components."""
         self.quick_thinking_llm = quick_thinking_llm
@@ -39,6 +45,7 @@ class GraphSetup:
         self.invest_judge_memory = invest_judge_memory
         self.risk_manager_memory = risk_manager_memory
         self.conditional_logic = conditional_logic
+        self.gateway = gateway
 
     def setup_graph(
         self, selected_analysts=["market", "social", "news", "fundamentals"]

--- a/tradingagents/infrastructure/external/__init__.py
+++ b/tradingagents/infrastructure/external/__init__.py
@@ -1,0 +1,35 @@
+"""Infrastructure-level gateway and provider adapters for external services."""
+
+from .adapters import (
+    AnthropicProviderAdapter,
+    BaseProviderAdapter,
+    FinnhubProviderAdapter,
+    GoogleProviderAdapter,
+    OfflineCacheAdapter,
+    OpenAIProviderAdapter,
+    RedditProviderAdapter,
+    SimFinProviderAdapter,
+    YahooFinanceProviderAdapter,
+)
+from .gateway import (
+    ExternalApiGateway,
+    ProviderInvocationError,
+    ProviderNotRegisteredError,
+    build_default_gateway,
+)
+
+__all__ = [
+    "AnthropicProviderAdapter",
+    "BaseProviderAdapter",
+    "FinnhubProviderAdapter",
+    "GoogleProviderAdapter",
+    "OfflineCacheAdapter",
+    "OpenAIProviderAdapter",
+    "RedditProviderAdapter",
+    "SimFinProviderAdapter",
+    "YahooFinanceProviderAdapter",
+    "ExternalApiGateway",
+    "ProviderInvocationError",
+    "ProviderNotRegisteredError",
+    "build_default_gateway",
+]

--- a/tradingagents/infrastructure/external/adapters.py
+++ b/tradingagents/infrastructure/external/adapters.py
@@ -1,0 +1,93 @@
+"""Provider adapter stubs for the ExternalApiGateway.
+
+The actual implementations will be fleshed out in later modernization
+stories. For now they provide a consistent interface for the gateway and
+allow tests to register doubles without hitting live services.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Protocol
+
+__all__ = [
+    "BaseProviderAdapter",
+    "OpenAIProviderAdapter",
+    "AnthropicProviderAdapter",
+    "GoogleProviderAdapter",
+    "FinnhubProviderAdapter",
+    "YahooFinanceProviderAdapter",
+    "RedditProviderAdapter",
+    "SimFinProviderAdapter",
+    "OfflineCacheAdapter",
+]
+
+
+class BaseProviderAdapter(Protocol):
+    """Protocol for provider adapters consumed by the gateway."""
+
+    provider_name: str
+
+    def invoke(
+        self,
+        operation: str,
+        payload: Mapping[str, Any] | None = None,
+        *,
+        timeout: float | None = None,
+    ) -> Any:
+        ...
+
+
+@dataclass
+class _StubAdapter:
+    provider_name: str
+
+    def invoke(
+        self,
+        operation: str,
+        payload: Mapping[str, Any] | None = None,
+        *,
+        timeout: float | None = None,
+    ) -> Any:
+        raise NotImplementedError(
+            "Provider adapter stubs do not implement runtime behaviour yet."
+        )
+
+
+class OpenAIProviderAdapter(_StubAdapter):
+    def __init__(self) -> None:
+        super().__init__(provider_name="openai")
+
+
+class AnthropicProviderAdapter(_StubAdapter):
+    def __init__(self) -> None:
+        super().__init__(provider_name="anthropic")
+
+
+class GoogleProviderAdapter(_StubAdapter):
+    def __init__(self) -> None:
+        super().__init__(provider_name="google")
+
+
+class FinnhubProviderAdapter(_StubAdapter):
+    def __init__(self) -> None:
+        super().__init__(provider_name="finnhub")
+
+
+class YahooFinanceProviderAdapter(_StubAdapter):
+    def __init__(self) -> None:
+        super().__init__(provider_name="yahoo_finance")
+
+
+class RedditProviderAdapter(_StubAdapter):
+    def __init__(self) -> None:
+        super().__init__(provider_name="reddit")
+
+
+class SimFinProviderAdapter(_StubAdapter):
+    def __init__(self) -> None:
+        super().__init__(provider_name="simfin")
+
+
+class OfflineCacheAdapter(_StubAdapter):
+    def __init__(self) -> None:
+        super().__init__(provider_name="offline_cache")

--- a/tradingagents/infrastructure/external/gateway.py
+++ b/tradingagents/infrastructure/external/gateway.py
@@ -1,0 +1,184 @@
+"""External API gateway coordinating provider access.
+
+See ``docs-v2/new-architecture/final-architecture.md`` and
+``docs-v2/components/data-platform.md`` for the broader design context.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Mapping
+
+from tradingagents.infrastructure.external.adapters import BaseProviderAdapter
+
+__all__ = [
+    "ExternalApiGateway",
+    "ProviderInvocationError",
+    "ProviderNotRegisteredError",
+    "build_default_gateway",
+]
+
+
+class ExternalApiGatewayError(RuntimeError):
+    """Base error for gateway-related failures."""
+
+
+class ProviderNotRegisteredError(ExternalApiGatewayError):
+    """Raised when attempting to access a provider that has not been registered."""
+
+    def __init__(self, provider: str) -> None:
+        super().__init__(f"Provider '{provider}' is not registered with the gateway.")
+        self.provider = provider
+
+
+class ProviderInvocationError(ExternalApiGatewayError):
+    """Raised when a provider call fails after exhausting retries."""
+
+    def __init__(
+        self,
+        provider: str,
+        operation: str,
+        attempts: int,
+        last_error: Exception,
+    ) -> None:
+        message = (
+            f"Failed to invoke '{provider}.{operation}' after {attempts} attempts:"
+            f" {last_error}"
+        )
+        super().__init__(message)
+        self.provider = provider
+        self.operation = operation
+        self.attempts = attempts
+        self.last_error = last_error
+
+
+@dataclass(frozen=True)
+class GatewayConfig:
+    """Configuration defaults for the gateway."""
+
+    default_timeout: float | None = 30.0
+    max_retries: int = 2
+    retry_backoff_seconds: float = 0.0
+
+
+class ExternalApiGateway:
+    """Entry point for all outbound provider calls."""
+
+    def __init__(
+        self,
+        providers: Mapping[str, BaseProviderAdapter] | None = None,
+        *,
+        default_timeout: float | None = None,
+        max_retries: int | None = None,
+        retry_backoff_seconds: float | None = None,
+    ) -> None:
+        config = GatewayConfig(
+            default_timeout=default_timeout
+            if default_timeout is not None
+            else GatewayConfig.default_timeout,
+            max_retries=max_retries if max_retries is not None else GatewayConfig.max_retries,
+            retry_backoff_seconds=
+                retry_backoff_seconds
+                if retry_backoff_seconds is not None
+                else GatewayConfig.retry_backoff_seconds,
+        )
+        self._config = config
+        self._providers: Dict[str, BaseProviderAdapter] = {}
+        if providers:
+            for name, adapter in providers.items():
+                self.register_provider(name, adapter)
+
+    @property
+    def config(self) -> GatewayConfig:
+        return self._config
+
+    def register_provider(self, name: str, adapter: BaseProviderAdapter) -> None:
+        """Register a provider adapter with the gateway."""
+
+        self._providers[name.lower()] = adapter
+
+    def available_providers(self) -> tuple[str, ...]:
+        """Return a tuple of registered provider identifiers."""
+
+        return tuple(sorted(self._providers))
+
+    def invoke(
+        self,
+        provider: str,
+        operation: str,
+        payload: Mapping[str, Any] | None = None,
+        *,
+        timeout: float | None = None,
+        retries: int | None = None,
+    ) -> Any:
+        """Invoke an operation on the requested provider with retry semantics."""
+
+        adapter = self._providers.get(provider.lower())
+        if adapter is None:
+            raise ProviderNotRegisteredError(provider)
+
+        attempts = 0
+        max_attempts = 1 + (retries if retries is not None else self._config.max_retries)
+        effective_timeout = (
+            timeout if timeout is not None else self._config.default_timeout
+        )
+        last_error: Exception | None = None
+        while attempts < max_attempts:
+            attempts += 1
+            try:
+                payload_to_send: Mapping[str, Any] = (
+                    dict(payload) if payload is not None else {}
+                )
+                result = adapter.invoke(
+                    operation,
+                    payload_to_send,
+                    timeout=effective_timeout,
+                )
+                return result
+            except Exception as exc:  # pragma: no cover - branches covered via tests
+                last_error = exc
+                if attempts >= max_attempts:
+                    raise ProviderInvocationError(
+                        provider=provider,
+                        operation=operation,
+                        attempts=attempts,
+                        last_error=exc,
+                    ) from exc
+                if self._config.retry_backoff_seconds > 0:
+                    # Sleep omitted in tests for determinism; no-op placeholder.
+                    pass
+        raise ProviderInvocationError(provider, operation, attempts, last_error or Exception("Unknown error"))
+
+
+def build_default_gateway(
+    *,
+    default_timeout: float | None = None,
+    max_retries: int | None = None,
+    retry_backoff_seconds: float | None = None,
+) -> ExternalApiGateway:
+    """Construct a gateway populated with the default provider stubs."""
+
+    from tradingagents.infrastructure.external.adapters import (
+        AnthropicProviderAdapter,
+        FinnhubProviderAdapter,
+        GoogleProviderAdapter,
+        OfflineCacheAdapter,
+        OpenAIProviderAdapter,
+        RedditProviderAdapter,
+        SimFinProviderAdapter,
+        YahooFinanceProviderAdapter,
+    )
+
+    gateway = ExternalApiGateway(
+        default_timeout=default_timeout,
+        max_retries=max_retries,
+        retry_backoff_seconds=retry_backoff_seconds,
+    )
+    gateway.register_provider("openai", OpenAIProviderAdapter())
+    gateway.register_provider("anthropic", AnthropicProviderAdapter())
+    gateway.register_provider("google", GoogleProviderAdapter())
+    gateway.register_provider("finnhub", FinnhubProviderAdapter())
+    gateway.register_provider("yahoo_finance", YahooFinanceProviderAdapter())
+    gateway.register_provider("reddit", RedditProviderAdapter())
+    gateway.register_provider("simfin", SimFinProviderAdapter())
+    gateway.register_provider("offline_cache", OfflineCacheAdapter())
+    return gateway


### PR DESCRIPTION
## Summary
- add the SessionDataContext with namespace validation, duplicate protection, and helpers for orchestration
- introduce the GraphNode protocol, NodeKind enum, and NodeSpec metadata used by planners
- cover the new contracts with focused domain unit tests and update the modernization tracker

## Testing
- pytest tests/domain -q
- pytest -m e2e


------
https://chatgpt.com/codex/tasks/task_e_68d6a88922108320aa77e877996f79f5